### PR TITLE
Bug: ReferenceError: document is not defined

### DIFF
--- a/src/gtm-support.ts
+++ b/src/gtm-support.ts
@@ -66,7 +66,7 @@ export class GtmSupport {
    *
    * @returns `true` if the script runs in browser context.
    */
-  public isInBrowserContext: () => boolean = () => typeof window !== 'undefined';
+  public isInBrowserContext: () => boolean = () => typeof window !== 'undefined' && typeof document !== 'undefined';
 
   /**
    * Check if plugin is enabled.


### PR DESCRIPTION
Check if `document` is defined as well besides `window` . Fixes https://github.com/gtm-support/vue-gtm/issues/96