### PR TITLE
Make script source configurable for server-side GTM

### DIFF
--- a/src/gtm-support.ts
+++ b/src/gtm-support.ts
@@ -87,11 +87,12 @@ export class GtmSupport {
    * - the `loadScript` option is set to `true`
    *
    * @param enabled `true` to enable, `false` to disable. Default: `true`.
+   * @param source The URL of the script, if it differs from the default. Default: 'https://www.googletagmanager.com/gtm.js'.
    */
-  public enable(enabled: boolean = true): void {
+  public enable(enabled: boolean = true, source?: string): void {
     this.options.enabled = enabled;
 
-    if (this.isInBrowserContext() && enabled && !hasScript() && this.options.loadScript) {
+    if (this.isInBrowserContext() && enabled && !hasScript(source) && this.options.loadScript) {
       if (Array.isArray(this.id)) {
         this.id.forEach((id: string | GtmIdContainer) => {
           if (typeof id === 'string') {

--- a/src/options.ts
+++ b/src/options.ts
@@ -55,6 +55,12 @@ export interface GtmSupportOptions {
    */
   nonce?: string;
   /**
+   * The URL of the script; useful for server-side GTM.
+   *
+   * @default https://www.googletagmanager.com/gtm.js
+   */
+  source?: string;
+  /**
    * Plugin can be disabled by setting this to `false`.
    *
    * @example enabled: !!GDPR_Cookie

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,12 @@ export interface LoadScriptOptions {
    */
   parentElement?: HTMLElement;
   /**
+   * The URL of the script; useful for server-side GTM.
+   *
+   * @default https://www.googletagmanager.com/gtm.js
+   */
+  source?: string;
+  /**
    * Will be called when the script is loaded.
    *
    * @param options Object containing container `id` and `script` element.
@@ -90,22 +96,26 @@ export function loadScript(id: string, config: LoadScriptOptions): void {
     id,
     ...(config.queryParams ?? {})
   });
-  script.src = `https://www.googletagmanager.com/gtm.js?${queryString}`;
+
+  const source: string = config.source ?? 'https://www.googletagmanager.com/gtm.js';
+
+  script.src = `${source}?${queryString}`;
 
   const parentElement: HTMLElement = config.parentElement ?? doc.body;
+
   if (typeof parentElement?.appendChild !== 'function') {
     throw new Error('parentElement must be a DOM element');
   }
+
   parentElement.appendChild(script);
 }
 
 /**
  * Check if GTM script is in the document.
  *
- * @returns `true` if in the `document` is a `script` with `src` containing `googletagmanager.com/gtm.js`, otherwise `false`.
+ * @param source The URL of the script, if it differs from the default. Default: 'https://www.googletagmanager.com/gtm.js'.
+ * @returns `true` if in the `document` is a `script` with `src` containing "https://www.googletagmanager.com/gtm.js" (or `source` if specified), otherwise `false`.
  */
-export function hasScript(): boolean {
-  return Array.from(document.getElementsByTagName('script')).some((script) =>
-    script.src.includes('googletagmanager.com/gtm.js')
-  );
+export function hasScript(source: string = 'https://www.googletagmanager.com/gtm.js'): boolean {
+  return Array.from(document.getElementsByTagName('script')).some((script) => script.src.includes(source));
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,7 +114,7 @@ export function loadScript(id: string, config: LoadScriptOptions): void {
  * Check if GTM script is in the document.
  *
  * @param source The URL of the script, if it differs from the default. Default: 'https://www.googletagmanager.com/gtm.js'.
- * @returns `true` if in the `document` is a `script` with `src` containing "https://www.googletagmanager.com/gtm.js" (or `source` if specified), otherwise `false`.
+ * @returns `true` if in the `document` is a `script` with `src` containing `'https://www.googletagmanager.com/gtm.js'` (or `source` if specified), otherwise `false`.
  */
 export function hasScript(source: string = 'https://www.googletagmanager.com/gtm.js'): boolean {
   return Array.from(document.getElementsByTagName('script')).some((script) => script.src.includes(source));

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -165,6 +165,26 @@ describe('utils', () => {
       expect(document.head.getElementsByTagName('script')[0]).toBe(document.scripts.item(0));
     });
 
+    // Test source
+    test(JSON.stringify({ compatibility: false, defer: false, source: 'https://analytics.example.com/gtm.js' }), () => {
+      expect(window.dataLayer).toBeUndefined();
+      expect(document.scripts.length).toBe(0);
+
+      loadScript('GTM-DEMO', {
+        compatibility: false,
+        defer: false,
+        source: 'https://analytics.example.com/gtm.js'
+      });
+
+      expectDataLayerToBeCorrect();
+      expectScriptToBeCorrect({
+        src: 'https://analytics.example.com/gtm.js?id=GTM-DEMO',
+        async: true,
+        defer: false,
+        nonce: ''
+      });
+    });
+
     // Test onReady
     test(
       JSON.stringify({
@@ -218,6 +238,14 @@ describe('utils', () => {
       document.body.appendChild(script);
 
       expect(hasScript()).toBe(false);
+    });
+
+    test('true - custom script', () => {
+      const script: HTMLScriptElement = document.createElement('script');
+      script.src = 'https://analytics.example.com/gtm.js';
+      document.body.appendChild(script);
+
+      expect(hasScript('https://analytics.example.com/gtm.js')).toBe(true);
     });
 
     test('true - multiple scripts', () => {


### PR DESCRIPTION
[Server-side GTM](https://developers.google.com/tag-platform/tag-manager/server-side) makes it possible to load `gtm.js` from a custom server container, as opposed to `https://www.googletagmanager.com`.

This changeset makes the script source configurable in order to facilitate this behavior.

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] Test integration with external codebase