### PR TITLE
Add configurable MIME type to script tag

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -49,6 +49,10 @@ export interface GtmSupportOptions {
    */
   compatibility?: boolean;
   /**
+   * Will add specified MIME type to script tag.
+   */
+  scriptType?: string;
+  /**
    * Will add `nonce` to the script tag.
    *
    * @see [Using Google Tag Manager with a Content Security Policy](https://developers.google.com/tag-manager/web/csp)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,7 +101,7 @@ export function loadScript(
   }
 
   if (config.scriptType) {
-    script.type = config.scriptType
+    script.type = config.scriptType;
   }
 
   const queryString: URLSearchParams = new URLSearchParams({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,10 @@ export interface LoadScriptOptions {
    */
   compatibility: boolean;
   /**
+   * Will add specified MIME type to script tag.
+   */
+  type?: string;
+  /**
    * Will add `nonce` to the script tag.
    *
    * @see [Using Google Tag Manager with a Content Security Policy](https://developers.google.com/tag-manager/web/csp)
@@ -94,6 +98,10 @@ export function loadScript(
 
   if (config.nonce) {
     script.nonce = config.nonce;
+  }
+
+  if (config.type) {
+    script.type = config.type
   }
 
   const queryString: URLSearchParams = new URLSearchParams({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export interface LoadScriptOptions {
   /**
    * Will add specified MIME type to script tag.
    */
-  type?: string;
+  scriptType?: string;
   /**
    * Will add `nonce` to the script tag.
    *
@@ -100,8 +100,8 @@ export function loadScript(
     script.nonce = config.nonce;
   }
 
-  if (config.type) {
-    script.type = config.type
+  if (config.scriptType) {
+    script.type = config.scriptType
   }
 
   const queryString: URLSearchParams = new URLSearchParams({

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -21,12 +21,14 @@ describe('utils', () => {
       async: boolean;
       defer: boolean;
       nonce: string;
+      scriptType: string;
     };
     function expectScriptToBeCorrect({
       src,
       async,
       defer,
       nonce,
+      scriptType,
     }: ScriptChecks): void {
       expect(document.scripts.length).toBe(1);
 
@@ -38,6 +40,7 @@ describe('utils', () => {
       expect(script.async).toBe(async);
       expect(script.defer).toBe(defer);
       expect(script.nonce).toBe(nonce);
+      expect(script.type).toBe(scriptType);
     }
 
     afterEach(() => {
@@ -60,6 +63,7 @@ describe('utils', () => {
         async: true,
         defer: false,
         nonce: '',
+        scriptType: '',
       });
       expect(script).toBe(document.scripts.item(0));
     });
@@ -79,6 +83,7 @@ describe('utils', () => {
         async: true,
         defer: true,
         nonce: '',
+        scriptType: '',
       });
       expect(script).toBe(document.scripts.item(0));
     });
@@ -98,6 +103,7 @@ describe('utils', () => {
         async: false,
         defer: true,
         nonce: '',
+        scriptType: '',
       });
       expect(script).toBe(document.scripts.item(0));
     });
@@ -117,6 +123,7 @@ describe('utils', () => {
         async: false,
         defer: true,
         nonce: '',
+        scriptType: '',
       });
       expect(script).toBe(document.scripts.item(0));
     });
@@ -140,6 +147,36 @@ describe('utils', () => {
           async: true,
           defer: false,
           nonce: 'test',
+          scriptType: '',
+        });
+        expect(script).toBe(document.scripts.item(0));
+      },
+    );
+
+    // Test MIME type
+    test(
+      JSON.stringify({
+        compatibility: false,
+        defer: false,
+        scriptType: 'text/test',
+      }),
+      () => {
+        expect(window.dataLayer).toBeUndefined();
+        expect(document.scripts.length).toBe(0);
+
+        const script: HTMLScriptElement = loadScript('GTM-DEMO', {
+          compatibility: false,
+          defer: false,
+          scriptType: 'text/test',
+        });
+
+        expectDataLayerToBeCorrect();
+        expectScriptToBeCorrect({
+          src: 'https://www.googletagmanager.com/gtm.js?id=GTM-DEMO',
+          async: true,
+          defer: false,
+          nonce: '',
+          scriptType: 'text/test',
         });
         expect(script).toBe(document.scripts.item(0));
       },
@@ -168,6 +205,7 @@ describe('utils', () => {
           async: true,
           defer: false,
           nonce: '',
+          scriptType: '',
         });
         expect(script).toBe(document.scripts.item(0));
       },
@@ -223,6 +261,7 @@ describe('utils', () => {
           async: true,
           defer: false,
           nonce: '',
+          scriptType: '',
         });
         expect(script).toBe(document.scripts.item(0));
       },


### PR DESCRIPTION
Some tools (such as partytown) require changing the MIME type of the inserted script tag. For partytown, it should be `text/partytown` ([here](https://partytown.builder.io/partytown-scripts#partytown-script-type)).

This PR introduces the optional ability to specify custom MIME type for the inserted script tag with GTM.

There's also a [discussion](https://github.com/gtm-support/vue-gtm/discussions/347) in `vue-gtm` which asks about the same feature.