### PR TITLE
Add `push` method to the `GtmSupport` class

### DIFF
--- a/src/gtm-support.ts
+++ b/src/gtm-support.ts
@@ -159,7 +159,7 @@ export class GtmSupport {
   /**
    * Track a view event with `event: "content-view"`.
    *
-   * The event will only be send if the script runs in browser context and the if plugin is enabled.
+   * The event will only be send if the script runs in browser context and the plugin is enabled.
    *
    * If debug mode is enabled, a "Dispatching TrackView" is logged,
    * regardless of whether the plugin is enabled or the plugin is being executed in browser context.
@@ -197,7 +197,7 @@ export class GtmSupport {
   /**
    * Track an event.
    *
-   * The event will only be send if the script runs in browser context and the if plugin is enabled.
+   * The event will only be send if the script runs in browser context and the plugin is enabled.
    *
    * If debug mode is enabled, a "Dispatching event" is logged,
    * regardless of whether the plugin is enabled or the plugin is being executed in browser context.
@@ -247,6 +247,33 @@ export class GtmSupport {
         'interaction-type': noninteraction,
         ...rest,
       });
+    }
+  }
+
+  /**
+   * Track an event by pushing the custom data directly to the `window.dataLayer`.
+   *
+   * The event will only be send if the script runs in browser context and the plugin is enabled.
+   *
+   * If debug mode is enabled, a "Dispatching event" is logged,
+   * regardless of whether the plugin is enabled or the plugin is being executed in browser context.
+   *
+   * @param data Event data object that is pushed to the `window.dataLayer`.
+   */
+  public push(data: DataLayerObject): void {
+    const trigger: boolean =
+      this.isInBrowserContext() && (this.options.enabled ?? false);
+    if (this.options.debug) {
+      console.log(
+        `[GTM-Support${trigger ? '' : '(disabled)'}]: Dispatching event`,
+        data,
+      );
+    }
+
+    if (trigger) {
+      const dataLayer: DataLayerObject[] = (window.dataLayer =
+        window.dataLayer ?? []);
+      dataLayer.push(data);
     }
   }
 }

--- a/tests/gtm-support.test.ts
+++ b/tests/gtm-support.test.ts
@@ -55,6 +55,7 @@ describe('gtm-support', () => {
     expect(instance.debugEnabled).toBeInstanceOf(Function);
 
     expect(instance.dataLayer).toBeInstanceOf(Function);
+    expect(instance.push).toBeInstanceOf(Function);
 
     expect(instance.trackView).toBeInstanceOf(Function);
     expect(instance.trackEvent).toBeInstanceOf(Function);
@@ -129,6 +130,23 @@ describe('gtm-support', () => {
             value: null,
           }),
         ]),
+      );
+    });
+
+    test('should expose push function', () => {
+      const instance: GtmSupport = new GtmSupport({ id: 'GTM-DEMO' });
+
+      expect(instance.push).toBeInstanceOf(Function);
+
+      const data: Record<string, any> = {
+        event: 'Test event',
+        customProp: true,
+      };
+
+      instance.push(data);
+
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([expect.objectContaining(data)]),
       );
     });
   });


### PR DESCRIPTION
This PR adds additional `push` method to the `GtmSupport` class so that we can directly push track event data to the `dataLayer`. 
Also if `debug` mode is on, it will also display the data which will be pushed.