### PR TITLE
feat: add preserveKeys option for label & category

### DIFF
--- a/src/gtm-support.ts
+++ b/src/gtm-support.ts
@@ -221,6 +221,13 @@ export class GtmSupport {
   }: TrackEventOptions = {}): void {
     const trigger: boolean =
       this.isInBrowserContext() && (this.options.enabled ?? false);
+    const categoryKey: string = this.options.preserveKeys?.category
+      ? 'category'
+      : 'target';
+    const labelKey: string = this.options.preserveKeys?.label
+      ? 'label'
+      : 'target-properties';
+
     if (this.options.debug) {
       console.log(
         `[GTM-Support${trigger ? '' : '(disabled)'}]: Dispatching event`,
@@ -240,9 +247,9 @@ export class GtmSupport {
         window.dataLayer ?? []);
       dataLayer.push({
         event: event ?? 'interaction',
-        target: category,
+        [categoryKey]: category,
         action: action,
-        'target-properties': label,
+        [labelKey]: label,
         value: value,
         'interaction-type': noninteraction,
         ...rest,

--- a/src/options.ts
+++ b/src/options.ts
@@ -90,4 +90,13 @@ export interface GtmSupportOptions {
    * @default content-view
    */
   trackViewEventProperty?: string;
+  /**
+   * DataLayer category and label keys can be preserved
+   *
+   * @example preserveKeys: { category: true, label: true}
+   */
+  preserveKeys?: {
+    category?: boolean;
+    label?: boolean;
+  };
 }

--- a/tests/gtm-support.test.ts
+++ b/tests/gtm-support.test.ts
@@ -149,6 +149,54 @@ describe('gtm-support', () => {
         expect.arrayContaining([expect.objectContaining(data)]),
       );
     });
+
+    test('should preserve trackEvent category property', () => {
+      const instance: GtmSupport = new GtmSupport({
+        id: 'GTM-DEMO',
+        preserveKeys: { category: true },
+      });
+
+      expect(instance.trackEvent).toBeInstanceOf(Function);
+
+      instance.trackEvent();
+
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            action: null,
+            category: null,
+            event: 'interaction',
+            'interaction-type': false,
+            'target-properties': null,
+            value: null,
+          }),
+        ]),
+      );
+    });
+
+    test('should preserve trackEvent label property', () => {
+      const instance: GtmSupport = new GtmSupport({
+        id: 'GTM-DEMO',
+        preserveKeys: { label: true },
+      });
+
+      expect(instance.trackEvent).toBeInstanceOf(Function);
+
+      instance.trackEvent();
+
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            action: null,
+            event: 'interaction',
+            'interaction-type': false,
+            label: null,
+            target: null,
+            value: null,
+          }),
+        ]),
+      );
+    });
   });
 
   describe('update script', () => {


### PR DESCRIPTION
This PR adds a `preserveKeys` option to keep the `category` and `label` keys in the dataLayer.