### PR TITLE
fix: add nonce as attribute to script

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,7 +137,7 @@ export function loadScript(
   script.defer = Boolean(config.defer || config.compatibility);
 
   if (config.nonce) {
-    script.nonce = config.nonce;
+    script.setAttribute('nonce', config.nonce);
   }
 
   if (config.scriptType) {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -42,7 +42,11 @@ describe('utils', () => {
       expect(script.src).toBe(src);
       expect(script.async).toBe(async);
       expect(script.defer).toBe(defer);
-      expect(script.nonce).toBe(nonce);
+      if (nonce !== undefined && nonce !== '') {
+        expect(script.getAttribute('nonce')).toBe(nonce);
+      } else {
+        expect(script.getAttribute('nonce')).toBe(null);
+      }
       expect(script.type).toBe(scriptType);
     }
 


### PR DESCRIPTION
Nonce attribute is not added as an attribute to the script tag, see:
[https://github.com/gtm-support/vue-gtm/issues/354](https://github.com/gtm-support/vue-gtm/issues/354)
[https://github.com/gtm-support/vue-gtm/issues/413](https://github.com/gtm-support/vue-gtm/issues/413)

Nonce was added as a property to the script object, but not rendered to the HTML script tag, which would cause script loading block with enabled CSP.